### PR TITLE
Added in Falcon512Fingerprint + 2 new files

### DIFF
--- a/src/cryptoconditions/Makefile.am
+++ b/src/cryptoconditions/Makefile.am
@@ -73,6 +73,7 @@ libcryptoconditions_core_la_SOURCES = \
 	src/asn/EvalFulfillment.c \
 	src/asn/Secp256k1FingerprintContents.c \
 	src/asn/Secp256k1Fulfillment.c \
+	src/asn/Falcon512FingerprintContents.c \
 	src/asn/INTEGER.c \
 	src/asn/NativeEnumerated.c \
 	src/asn/NativeInteger.c \

--- a/src/cryptoconditions/src/asn/Condition.h
+++ b/src/cryptoconditions/src/asn/Condition.h
@@ -28,7 +28,8 @@ typedef enum Condition_PR {
 	Condition_PR_rsaSha256,
 	Condition_PR_ed25519Sha256,
 	Condition_PR_secp256k1Sha256,
-	Condition_PR_evalSha256
+	Condition_PR_evalSha256,
+	Condition_PR_falcon512
 } Condition_PR;
 
 /* Condition */

--- a/src/cryptoconditions/src/asn/Falcon512FingerprintContents.c
+++ b/src/cryptoconditions/src/asn/Falcon512FingerprintContents.c
@@ -1,0 +1,79 @@
+
+
+#include "Falcon512FingerprintContents.h"
+
+static int
+memb_publicKey_constraint_1(asn_TYPE_descriptor_t *td, const void *sptr,
+			asn_app_constraint_failed_f *ctfailcb, void *app_key) {
+	const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
+	size_t size;
+	
+	if(!sptr) {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: value not given (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+	
+	size = st->size;
+	
+	if((size == 33)) {
+		/* Constraint check succeeded */
+		return 0;
+	} else {
+		ASN__CTFAIL(app_key, td, sptr,
+			"%s: constraint failed (%s:%d)",
+			td->name, __FILE__, __LINE__);
+		return -1;
+	}
+}
+
+static asn_TYPE_member_t asn_MBR_Falcon512FingerprintContents_1[] = {
+	{ ATF_NOFLAGS, 0, offsetof(struct Falcon512FingerprintContents, publicKey),
+		(ASN_TAG_CLASS_CONTEXT | (0 << 2)),
+		-1,	/* IMPLICIT tag at current level */
+		&asn_DEF_OCTET_STRING,
+		memb_publicKey_constraint_1,
+		0,	/* PER is not compiled, use -gen-PER */
+		0,
+		"publicKey"
+		},
+};
+static const ber_tlv_tag_t asn_DEF_Falcon512FingerprintContents_tags_1[] = {
+	(ASN_TAG_CLASS_UNIVERSAL | (16 << 2))
+};
+static const asn_TYPE_tag2member_t asn_MAP_Falcon512FingerprintContents_tag2el_1[] = {
+    { (ASN_TAG_CLASS_CONTEXT | (0 << 2)), 0, 0, 0 } /* publicKey */
+};
+static asn_SEQUENCE_specifics_t asn_SPC_Falcon512FingerprintContents_specs_1 = {
+	sizeof(struct Falcon512FingerprintContents),
+	offsetof(struct Falcon512FingerprintContents, _asn_ctx),
+	asn_MAP_Falcon512FingerprintContents_tag2el_1,
+	1,	/* Count of tags in the map */
+	0, 0, 0,	/* Optional elements (not needed) */
+	-1,	/* Start extensions */
+	-1	/* Stop extensions */
+};
+asn_TYPE_descriptor_t asn_DEF_Falcon512FingerprintContents = {
+	"Falcon512FingerprintContents",
+	"Falcon512FingerprintContents",
+	SEQUENCE_free,
+	SEQUENCE_print,
+	SEQUENCE_constraint,
+	SEQUENCE_decode_ber,
+	SEQUENCE_encode_der,
+	SEQUENCE_decode_xer,
+	SEQUENCE_encode_xer,
+	0, 0,	/* No PER support, use "-gen-PER" to enable */
+	0,	/* Use generic outmost tag fetcher */
+	asn_DEF_Falcon512FingerprintContents_tags_1,
+	sizeof(asn_DEF_Falcon512FingerprintContents_tags_1)
+		/sizeof(asn_DEF_Falcon512FingerprintContents_tags_1[0]), /* 1 */
+	asn_DEF_Falcon512FingerprintContents_tags_1,	/* Same as above */
+	sizeof(asn_DEF_Falcon512FingerprintContents_tags_1)
+		/sizeof(asn_DEF_Falcon512FingerprintContents_tags_1[0]), /* 1 */
+	0,	/* No PER visible constraints */
+	asn_MBR_Falcon512FingerprintContents_1,
+	1,	/* Elements count */
+	&asn_SPC_Falcon512FingerprintContents_specs_1	/* Additional specs */
+};

--- a/src/cryptoconditions/src/asn/Falcon512FingerprintContents.h
+++ b/src/cryptoconditions/src/asn/Falcon512FingerprintContents.h
@@ -1,0 +1,32 @@
+
+#ifndef	_Falcon512FingerprintContents_H_
+#define	_Falcon512FingerprintContents_H_
+
+
+#include "asn_application.h"
+
+/* Including external dependencies */
+#include <OCTET_STRING.h>
+#include <constr_SEQUENCE.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Falcon512FingerprintContents */
+typedef struct Falcon512FingerprintContents {
+	OCTET_STRING_t	 publicKey;
+	
+	/* Context for parsing across buffer boundaries */
+	asn_struct_ctx_t _asn_ctx;
+} Falcon512FingerprintContents_t;
+
+/* Implementation */
+extern asn_TYPE_descriptor_t asn_DEF_Falcon512FingerprintContents;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* _Falcon512FingerprintContents_H_ */
+#include <asn_internal.h>

--- a/src/cryptoconditions/src/falcon512.c
+++ b/src/cryptoconditions/src/falcon512.c
@@ -14,6 +14,7 @@
 #include "internal.h"
 #include "asn/OCTET_STRING.h"
 #include "include/falcon/falcon.h"
+#include "asn/Falcon512FingerprintContents.h"
 
 struct CCType CC_Falcon512Type;
 
@@ -127,3 +128,79 @@ int cc_VerifyFalcon512Key(const unsigned char *msg32, const unsigned char *publi
 
     return 1;
 }
+
+static unsigned char *falcon512Fingerprint(const CC *cond) {
+    Falcon512FingerprintContents_t *fp = calloc(1, sizeof(Falcon512FingerprintContents_t));
+    OCTET_STRING_fromBuf(&fp->publicKey, cond->publicKey, FALCON_PUBKEY_SIZE(9));
+    return Falcon512hashFingerprintContents(&asn_DEF_Falcon512FingerprintContents, fp);
+}
+
+static unsigned long falcon512Cost(const CC *cond) {
+    return 131072;
+}
+
+
+//static CC *cc_falcon512Condition(const unsigned char *publicKey, const unsigned char *signature) {
+  
+  //  return 0;
+//}
+
+
+static CC *falcon512FromJSON(const cJSON *params, char *err) {
+  //  CC *cond = 0;
+  //  unsigned char *pk = 0, *sig = 0;
+ //   size_t pkSize, sigSize;
+
+    return 0;
+}
+
+
+static void falcon512ToJSON(const CC *cond, cJSON *params) {
+
+}
+
+
+static CC *falcon512FromFulfillment(const Fulfillment_t *ffill) {
+    return 0;
+}
+
+
+static Fulfillment_t *falcon512ToFulfillment(const CC *cond) {
+    if (!cond->signature) {
+        return NULL;
+    }
+
+    return 0;
+}
+
+
+static CC *falcon512FromPartialFulfillment(const Fulfillment_t *ffill) {
+    return 0;
+}
+
+
+static Fulfillment_t *falcon512ToPartialFulfillment(const CC *cond) {
+
+    
+    return 0;
+}
+
+
+int falcon512IsFulfilled(const CC *cond) {
+    return cond->signature != 0;
+}
+
+
+static void falcon512Free(CC *cond) {
+    free(cond->publicKey);
+    if (cond->signature) {
+        free(cond->signature);
+    }
+}
+
+
+static uint32_t falcon512Subtypes(const CC *cond) {
+    return 0;
+}
+
+struct CCType CC_Falcon512Type = { 5, "falcon512-sha-256", Condition_PR_falcon512, 0, &falcon512Fingerprint, &falcon512Cost, &falcon512Subtypes, &falcon512FromJSON, &falcon512ToJSON, &falcon512FromFulfillment, &falcon512ToFulfillment, &falcon512FromPartialFulfillment, &falcon512ToPartialFulfillment, &falcon512IsFulfilled, &falcon512Free };

--- a/src/cryptoconditions/src/internal.h
+++ b/src/cryptoconditions/src/internal.h
@@ -82,6 +82,7 @@ struct CCType *getTypeByAsnEnum(Condition_PR present);
 unsigned char *base64_encode(const unsigned char *data, size_t input_length);
 unsigned char *base64_decode(const unsigned char *data_, size_t *output_length);
 unsigned char *hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp);
+unsigned char *Falcon512hashFingerprintContents(asn_TYPE_descriptor_t *asnType, void *fp);
 void dumpStr(unsigned char *str, size_t len);
 int checkString(const cJSON *value, char *key, char *err);
 int checkDecodeBase64(const cJSON *value, char *key, char *err, unsigned char **data, size_t *size);


### PR DESCRIPTION
Added in 
cryptoconditions/src/asn/Falcon512FingerprintContents.c
cryptoconditions/src/asn/Falcon512FingerprintContents.h

Each subroutines in all new falcon associated files need to be checked over, for burffer  size lengths data  input  /out lengths.

Also fingerprintfalcon subroutines asre currently blank as not sure how they work.

Not sure if Falcon512hashFingerprintContents()  in  src/cryptoconditions/src/utils.h should pass a shake hash back?
