### PR TITLE
Add '-blocktime' and '-averagingwindow' startup flags

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -107,12 +107,10 @@ public:
         consensus.nEquihashN = N;
         consensus.nEquihashK = K;
         consensus.nPowAveragingWindow = 17;
-        consensus.nMaxFutureBlockTime = 7 * 60; // 7 mins
 
         assert(maxUint/UintToArith256(consensus.powLimit) >= consensus.nPowAveragingWindow);
         consensus.nPowMaxAdjustDown = 32; // 32% adjustment down
         consensus.nPowMaxAdjustUp = 16; // 16% adjustment up
-        consensus.nPowTargetSpacing = 1 * 60;
         consensus.nPreBlossomPowTargetSpacing = Consensus::PRE_BLOSSOM_POW_TARGET_SPACING;
         consensus.nPostBlossomPowTargetSpacing = Consensus::POST_BLOSSOM_POW_TARGET_SPACING;
         consensus.nPowAllowMinDifficultyBlocksAfterHeight = boost::none;
@@ -145,7 +143,6 @@ public:
         // (Zcash) vAlertPubKey = ParseHex("04b7ecf0baa90495ceb4e4090f6b2fd37eec1e9c85fac68a487f3ce11589692e4a317479316ee814e066638e1db54e37a10689b70286e6315b1087b6615d179264");
         nDefaultPort = 7770;
         nMinerThreads = 0;
-        nMaxTipAge = 24 * 60 * 60;
         nPruneAfterHeight = 100000;
 
         const char* pszTimestamp = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks";
@@ -241,13 +238,25 @@ void *chainparams_commandline(void *ptr)
         mainParams.pchMessageStart[3] = (ASSETCHAINS_MAGIC >> 24) & 0xff;
         fprintf(stderr,">>>>>>>>>> %s: p2p.%u rpc.%u magic.%08x %u %lu coins\n",ASSETCHAINS_SYMBOL,ASSETCHAINS_P2PPORT,ASSETCHAINS_RPCPORT,ASSETCHAINS_MAGIC,ASSETCHAINS_MAGIC,ASSETCHAINS_SUPPLY / COIN);
 
+        int64_t nBlockTime = GetArg("-blocktime",DEFAULT_BLOCKTIME_TARGET);
+        mainParams.SetBlockTime(nBlockTime);
+
         if (ASSETCHAINS_ALGO != ASSETCHAINS_EQUIHASH)
         {
             // this is only good for 60 second blocks with an averaging window of 45. for other parameters, use:
-            // nLwmaAjustedWeight = (N+1)/2 * (0.9989^(500/nPowAveragingWindow)) * nPowTargetSpacing 
-            mainParams.consensus.nLwmaAjustedWeight = 1350;
-            mainParams.consensus.nPowAveragingWindow = 45;
+            // nLwmaAjustedWeight = (N+1)/2 * (0.9989^(500/nPowAveragingWindow)) * nPowTargetSpacing
+            int64_t PowAveragingWindow = GetArg("-averagingwindow",DEFAULT_AVERAGING_WINDOW);
+            mainParams.consensus.nPowAveragingWindow = PowAveragingWindow;
             mainParams.consensus.powAlternate = uint256S("00000f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f");
+
+            if (mainParams.consensus.nBlockTime != DEFAULT_BLOCKTIME_TARGET)
+            {
+                float weight = (float)((mainParams.consensus.nPowAveragingWindow+1)/2) * std::pow(0.9989f,(500.0f/((float)mainParams.consensus.nPowAveragingWindow))) * (float)mainParams.consensus.nBlockTime;
+                mainParams.consensus.nLwmaAjustedWeight = (((int)weight)/10)*10; // int conversion, round down to nearest mutiple of 10
+                //LogPrintf(">>> nLwmaAjustedWeight = %ld\n",mainParams.consensus.nLwmaAjustedWeight);
+            } else {
+                mainParams.consensus.nLwmaAjustedWeight = 1350;
+            }
         }
 
         if (ASSETCHAINS_LWMAPOS != 0)
@@ -778,6 +787,14 @@ void EnableCoinbaseMustBeProtected()
 bool AreParamsInitialized()
 {
     return (pCurrentParams != NULL);
+}
+
+void CChainParams::SetBlockTime(uint64_t blockTime)
+{
+    consensus.nBlockTime = blockTime;
+    consensus.nMaxFutureBlockTime = 7 * consensus.nBlockTime;
+    consensus.nPowTargetSpacing = consensus.nBlockTime;
+    nMaxTipAge = 24 * 60 * consensus.nBlockTime;
 }
 
 CChainParams &Params(CBaseChainParams::Network network) {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -125,6 +125,8 @@ public:
     CMessageHeader::MessageStartChars pchMessageStart; // jl777 moved
     Consensus::Params consensus;
 
+    void SetBlockTime(uint64_t blockTime);
+
 protected:
     CChainParams() {}
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -124,6 +124,7 @@ struct Params {
     int64_t nPowMaxAdjustDown;
     int64_t nPowMaxAdjustUp;
     int64_t nPowTargetSpacing;
+    int64_t nBlockTime;
     int64_t nLwmaAjustedWeight;
 
     /* Proof of stake parameters */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -515,6 +515,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-miningdistribution={\"addressorid\":<n>,...}", _("destination addresses and relative amounts used as ratios to divide total rewards + fees"));
     strUsage += HelpMessageOpt("-miningdistributionpassthrough", _("uses the same miningdistribution values and addresses/IDs as Verus when merge mining"));
     strUsage += HelpMessageOpt("-chain=pbaaschainname", _("loads either mainnet or resolves and loads a PBaaS chain if not vrsc or vrsctest"));
+    strUsage += HelpMessageOpt("-blocktime=<n>", strprintf(_("Set target block time (in seconds) for difficulty adjustment (default: %d)"), DEFAULT_BLOCKTIME_TARGET));
+    strUsage += HelpMessageOpt("-averagingwindow=<n>", strprintf(_("Set averaging window for difficulty adjustment, in blocks (default: %d)"), DEFAULT_AVERAGING_WINDOW));
     strUsage += HelpMessageOpt("-testnet", _("loads PBaaS network in testmode"));
 
     strUsage += HelpMessageGroup(_("Node relay options:"));

--- a/src/main.h
+++ b/src/main.h
@@ -58,6 +58,10 @@ struct CNodeStateStats;
 #define DEFAULT_MEMPOOL_EXPIRY 1
 #define _COINBASE_MATURITY 100
 
+/** Default block time target for difficulty adjustment, in seconds **/
+static const unsigned int DEFAULT_BLOCKTIME_TARGET = 60;
+/** Default target spacing (blocks) for difficulty adjustment **/
+static const unsigned int DEFAULT_AVERAGING_WINDOW = 45;
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = MAX_BLOCK_SIZE;
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;


### PR DESCRIPTION
Gives VerusCoin a fully configurable DAA.  In event these are not supplied on startup, regular values of `blocktime=60` and `averagingwindow=45` are used. 