### PR TITLE
Maxed out function failing with two zero values.

### DIFF
--- a/src/pbaas/pbaas.cpp
+++ b/src/pbaas/pbaas.cpp
@@ -6350,7 +6350,7 @@ bool IsMaxed(const std::map<uint160, std::pair<int, int>> &maxTrackerMap)
 {
     for (auto &oneCheck : maxTrackerMap)
     {
-        if (oneCheck.second.second >= oneCheck.second.first)
+        if (oneCheck.second.second >= oneCheck.second.first && (oneCheck.second.second | oneCheck.second.first))
         {
             return true;
         }


### PR DESCRIPTION
If maximum and amount are both 0 dont consider them as maxed out.