### PR TITLE
Merge mining improvements with getblocktemplate

### DIFF
--- a/src/komodo_utils.h
+++ b/src/komodo_utils.h
@@ -1745,8 +1745,6 @@ void komodo_args(char *argv0)
     if ( GetBoolArg("-gen", false) != 0 )
     {
         KOMODO_MININGTHREADS = GetArg("-genproclimit",-1);
-        if (KOMODO_MININGTHREADS == 0)
-            mapArgs["-gen"] = "0";
     }
     else KOMODO_MININGTHREADS = 0;
 

--- a/src/pbaas/pbaas.cpp
+++ b/src/pbaas/pbaas.cpp
@@ -4860,6 +4860,7 @@ bool CConnectedChains::AddMergedBlock(CPBaaSMergeMinedChainData &blkData)
         mergeMinedChains.insert(make_pair(cID, blkData));
         mergeMinedTargets.insert(make_pair(target, &(mergeMinedChains[cID])));
         dirty = true;
+        dirtygbt = true;
         nextBlockTimeUpdateRequired = true;
     }
 
@@ -5153,8 +5154,10 @@ uint32_t CConnectedChains::CombineBlocks(CBlockHeader &bh)
         }
         dirty = false;
     }
+    
+    saveBits = target.GetCompact();
 
-    return target.GetCompact();
+    return saveBits;
 }
 
 bool CConnectedChains::IsVerusPBaaSAvailable()

--- a/src/pbaas/pbaas.cpp
+++ b/src/pbaas/pbaas.cpp
@@ -10007,9 +10007,11 @@ void CConnectedChains::SubmissionThread()
 
                 // update block time on submit or PBaaS chain advances forward
                 if (submit || nextBlockTimeUpdateRequired) {
-                    //printf("SubmissionThread: update next block time\n");
-                    nextBlockTimeUpdateRequired = false;
+                    //SetNextBlockTime(0);
                     newNextTime = SetNextBlockTime(GetNextBlockTime(chainActive.LastTip()));
+
+                    //printf("blocktimeupdate: %d last time: %d new time: %d\n", nextBlockTimeUpdateRequired, lastNextTime, newNextTime);
+                    nextBlockTimeUpdateRequired = false;
                 }
 
                 // prune outdated blocks

--- a/src/pbaas/pbaas.cpp
+++ b/src/pbaas/pbaas.cpp
@@ -4934,6 +4934,7 @@ void CConnectedChains::QueueNewBlockHeader(CBlockHeader &bh)
         LOCK(cs_mergemining);
 
         qualifiedHeaders[UintToArith256(bh.GetHash())] = bh;
+
     }
     sem_submitthread.post();
 }
@@ -5075,6 +5076,9 @@ vector<pair<string, UniValue>> CConnectedChains::SubmitQualifiedBlocks()
             }
         }
     } while (submissionFound);
+    
+    SetNextBlockTime(0);
+    
     return results;
 }
 

--- a/src/pbaas/pbaas.cpp
+++ b/src/pbaas/pbaas.cpp
@@ -10007,7 +10007,7 @@ void CConnectedChains::SubmissionThread()
 
                 // update block time on submit or PBaaS chain advances forward
                 if (submit || nextBlockTimeUpdateRequired) {
-                    printf("SubmissionThread: update next block time\n");
+                    //printf("SubmissionThread: update next block time\n");
                     nextBlockTimeUpdateRequired = false;
                     newNextTime = SetNextBlockTime(GetNextBlockTime(chainActive.LastTip()));
                 }

--- a/src/pbaas/pbaas.h
+++ b/src/pbaas/pbaas.h
@@ -955,7 +955,11 @@ public:
     int32_t earnedNotarizationIndex;            // index of earned notarization in block
 
     bool dirty;
+    bool dirtygbt;
     bool lastSubmissionFailed;                  // if we submit a failed block, make another
+    
+    uint32_t saveBits;
+    
     std::map<arith_uint256, CBlockHeader> qualifiedHeaders;
 
     CCriticalSection cs_mergemining;
@@ -969,6 +973,8 @@ public:
         earnedNotarizationHeight(0),
         earnedNotarizationIndex(0),
         dirty(false),
+        dirtygbt(false),
+        saveBits(0),
         lastSubmissionFailed(false),
         sem_submitthread(0),
         nextBlockTime(0) {}

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -947,9 +947,9 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     }
     CBlock* pblock = &pblocktemplate->block; // pointer for convenience
 
-    uint32_t savebits;
-    savebits = pblock->nBits;
-    
+    static uint32_t gbtcachedsavebits;
+    uint32_t savebits = pblock->nBits;
+
     int64_t Mining_height = (int64_t)(pindexPrev->GetHeight()+1);
 
     // pickup/remove any new/deleted headers
@@ -957,6 +957,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     {
         unsigned int nExtraNonce = 0;
         IncrementExtraNonce(pblock, pindexPrev, nExtraNonce, true, &savebits);
+        gbtcachedsavebits = savebits;
     }
 
     // cache the last block or copy of last
@@ -1055,7 +1056,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_SIZE));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
-    result.push_back(Pair("mergeminebits", strprintf("%08x", savebits)));
+    result.push_back(Pair("mergeminebits", strprintf("%08x", gbtcachedsavebits)));
     result.push_back(Pair("nonce", pblock->nNonce.GetHex().c_str()));
     result.push_back(Pair("height", (int64_t)(pindexPrev->GetHeight()+1)));
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -947,22 +947,21 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     }
     CBlock* pblock = &pblocktemplate->block; // pointer for convenience
 
-    static uint32_t gbtcachedsavebits;
-    uint32_t savebits = pblock->nBits;
-
     int64_t Mining_height = (int64_t)(pindexPrev->GetHeight()+1);
 
     // pickup/remove any new/deleted headers
-    if (ConnectedChains.dirty || (pblock->NumPBaaSHeaders() < ConnectedChains.mergeMinedChains.size() + 1))
+    if (ConnectedChains.dirtygbt || (pblock->NumPBaaSHeaders() < ConnectedChains.mergeMinedChains.size() + 1))
     {
-        unsigned int nExtraNonce = 0;
-        IncrementExtraNonce(pblock, pindexPrev, nExtraNonce, true, &savebits);
-        gbtcachedsavebits = savebits;
+        ConnectedChains.dirtygbt = false;
+
+        uint32_t tmpsavebits; // unused
+        uint32_t tmpnonce = 0;
+        IncrementExtraNonce(pblock, pindexPrev, tmpnonce, true, &tmpsavebits);
     }
 
     // cache the last block or copy of last
     ConnectedChains.SetLastBlock(*pblock, Mining_height);
-    
+
     UniValue aCaps(UniValue::VARR); aCaps.push_back("proposal");
 
     UniValue txCoinbase = NullUniValue;
@@ -1056,7 +1055,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_SIZE));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
-    result.push_back(Pair("mergeminebits", strprintf("%08x", gbtcachedsavebits)));
+    result.push_back(Pair("mergeminebits", strprintf("%08x", ConnectedChains.saveBits)));
     result.push_back(Pair("nonce", pblock->nNonce.GetHex().c_str()));
     result.push_back(Pair("height", (int64_t)(pindexPrev->GetHeight()+1)));
 


### PR DESCRIPTION
- Allow `-gen` option with `-genproclimit=0` to spin up block submission thread for merged mining support.
- Update `getblocktemplate` to include merged mining sync improvements.