### PR TITLE
Update zlib version and download source

### DIFF
--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,8 +1,8 @@
 package=zlib
-$(package)_version=1.2.13
-$(package)_download_path=https://www.zlib.net
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
+$(package)_version=1.3
+$(package)_download_path=https://github.com/madler/zlib/releases/download/v$($(package)_version)
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7
 
 define $(package)_set_vars
 $(package)_config_opts= CC="$($(package)_cc)"
@@ -28,4 +28,3 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
-


### PR DESCRIPTION
https://www.zlib.net/ only has the latest release available to download so builds break with new versions are available, forcing an update. The download is now fetched from zlib's GitHub releases.
