### PR TITLE
Invalid parent currencies do not throw error

### DIFF
--- a/src/rpc/pbaasrpc.cpp
+++ b/src/rpc/pbaasrpc.cpp
@@ -11953,7 +11953,7 @@ UniValue registernamecommitment(const UniValue& params, bool fHelp)
         }
         parentID = ValidateCurrencyName(uni_get_str(params[3]), true, &parentCurrency);
 
-        if (!parentCurrency.IsValid())
+        if (!parentCurrency.IsValid() || parentID.IsNull())
         {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parent currency");
         }


### PR DESCRIPTION
Invalid parent currencies that are inputted as param[3] in a registernamecommitment do not throw an error. they get autochanged to vrsctest.  this checks that the return currency is valid.