### PR TITLE
TOR disabled by default

### DIFF
--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -11,7 +11,7 @@
 #include "scheduler.h"
 
 extern const std::string DEFAULT_TOR_CONTROL;
-static const bool DEFAULT_LISTEN_ONION = true;
+static const bool DEFAULT_LISTEN_ONION = false;
 
 void StartTorControl(boost::thread_group& threadGroup, CScheduler& scheduler);
 void InterruptTorControl();


### PR DESCRIPTION
TORv2 is deprecated, unsupported and no longer functional.

disable TORv2 by default, si the daemon won't automatically create a TOR hidden service.