### PR TITLE
Update `datadir` for PBaaS chains and add `notarydatadir` option for connected chains

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -370,6 +370,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-mempooltxinputlimit=<n>", _("[DEPRECATED FROM OVERWINTER] Set the maximum number of transparent inputs in a transaction that the mempool will accept (default: 0 = no limit applied)"));
+    strUsage += HelpMessageOpt("-notarydatadir=<dir>", _("Specify data directory for notary chain"));
     strUsage += HelpMessageOpt("-par=<n>", strprintf(_("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)"),
         -(int)boost::thread::hardware_concurrency(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS));
 #ifndef _WIN32

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -773,6 +773,10 @@ const boost::filesystem::path &GetDataDir(bool fNetSpecific)
             path = "";
             return path;
         }
+        if (!_IsVerusActive())
+        {
+            path /= CanonicalChainFileName(std::string(ASSETCHAINS_SYMBOL));
+        }
     } else {
         path = GetDefaultDataDir();
     }
@@ -790,24 +794,18 @@ const boost::filesystem::path GetDataDir(std::string chainName)
     namespace fs = boost::filesystem;
     fs::path path;
     std::string canonicalName = CanonicalChainFileName(chainName);
-
-    if ((canonicalName == "VRSC" || canonicalName == "vrsctest") && mapArgs.count("-datadir")) {
-        path = fs::system_complete(mapArgs["-datadir"]);
-        if (!fs::is_directory(path)) {
-            path = GetDefaultDataDir(chainName);
-        }
-    } else if (mapArgs.count("-datadir"))
+    bool isExternalChain = canonicalName != CanonicalChainFileName(std::string(ASSETCHAINS_SYMBOL));
+    bool isVerus = canonicalName == "VRSC" || canonicalName == "vrsctest";
+    std::string dataDirArg = isExternalChain ? "-notarydatadir" : "-datadir";
+    if (mapArgs.count(dataDirArg))
     {
-        path = fs::system_complete(mapArgs["-datadir"] + canonicalName);
-        if (!fs::is_directory(path)) {
-            path = GetDefaultDataDir(chainName);
-        }
+        path = fs::system_complete(mapArgs[dataDirArg]);
+        path = !fs::is_directory(path) ?
+               GetDefaultDataDir(chainName) : isVerus ?
+                                              path : path / canonicalName;
+        return path;
     }
-    else
-    {
-        path = GetDefaultDataDir(chainName);
-    }
-    return path;
+    return GetDefaultDataDir(chainName);
 }
 
 void ClearDatadirCache()


### PR DESCRIPTION
Reorganize the logic for determining the data directory to handle Verus and external chains more clearly. Add a new command-line option `-notarydatadir` to specify the data directory for connected chains.