### PR TITLE
Fix the signdata command to check for 5/6 empty data parameters

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1620,7 +1620,7 @@ UniValue signdata(const UniValue& params, bool fHelp)
                  (int)vdxfData.isNull() +
                  (int)strHex.empty() +
                  (int)strBase64.empty() +
-                 (int)strDataHash.empty()) != 4)
+                 (int)strDataHash.empty()) != 5)
             {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Must include one and only one of \"filename\", \"message\", \"messagehex\", \"messagebase64\", and \"datahash\"");
             }


### PR DESCRIPTION
The addition of `vdxfData` to the data parameters makes it so that there are 6 total parameters now and therefore there should be 5 empty parameters if there is only 1 non-empty one.