### PR TITLE
Allow vdxfuniobjects to be arrays

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -971,7 +971,7 @@ std::vector<unsigned char> VectorEncodeVDXFUniObjOrArray(const UniValue &obj)
     // if object push to an array 
     if(obj.isObject())
     {
-        newObj.push_back(oneValValues[k]);
+        newObj.push_back(obj);
     } 
     else if(obj.isArray())
     {


### PR DESCRIPTION
When deserializing a stream into uniobjects if there is more than one it will put them into an array.  however on encoding to a vector this does not happen.  So the only way to put uniobjects in of the same time is create an uniobject like this with the same key names.

```js
{
   "objectdata":{
      "i4GC1YGEVD21afWudGoFJVdnfjJ5XWnCQv":{
         "version":1,
         "mimetype":"text/plain",
         "objectdata":{
            "message":"IBM"
         },
         "label":"Employee"
      },
      "i4GC1YGEVD21afWudGoFJVdnfjJ5XWnCQv":{
         "version":1,
         "mimetype":"text/plain",
         "objectdata":{
            "message":"2000 - 2002"
         },
         "label":"date"
      }
   }
}