### PR TITLE
Update UniValue representation in Credential class

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -1486,7 +1486,7 @@ UniValue CCredential::ToUniValue() const
 
     ret.pushKV("version", (int64_t)version);
     ret.pushKV("flags", Flags);
-    ret.pushKV("credentialKey", EncodeDestination(CIdentityID(credentialKey)));
+    ret.pushKV("credentialkey", EncodeDestination(CIdentityID(credentialKey)));
 
     ret.pushKV("credential", credential);
     ret.pushKV("scopes", scopes);

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -961,7 +961,7 @@ CRating::CRating(const UniValue uni) :
 CCredential::CCredential(const UniValue uni) : 
     version(uni_get_int64(find_value(uni, "version"))),
     flags(uni_get_int64(find_value(uni, "flags"))),
-    credentialKey(GetDestinationID(DecodeDestination(uni_get_str(find_value(uni, "credentialKey"))))),
+    credentialKey(GetDestinationID(DecodeDestination(uni_get_str(find_value(uni, "credentialkey"))))),
     credential(find_value(uni, "credential")),
     scopes(find_value(uni, "scopes")),
     label(TrimSpaces(uni_get_str(find_value(uni, "label")), true, ""))

--- a/src/pbaas/identity.h
+++ b/src/pbaas/identity.h
@@ -1379,8 +1379,8 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(version);
-        READWRITE(flags);
+        READWRITE(VARINT(version));
+        READWRITE(VARINT(flags));
         READWRITE(credentialKey);
 
         if (ser_action.ForRead()) {


### PR DESCRIPTION
Fixes the following issues
1. Corrects `credentialKey` to use only lowercase letters in the UniValue representation.
2. Updates writing flags to use `varint` to save space.