### PR TITLE
Fix gcc 15 error: 'bool' cannot be defined via 'typedef'

### DIFF
--- a/src/cryptoconditions/src/internal.h
+++ b/src/cryptoconditions/src/internal.h
@@ -30,7 +30,11 @@ extern "C" {
 
 #define BUF_SIZE 5120
 
-typedef char bool;
+if defined(__STDC_VERSION__) && (__STDC_VERSION__ < 202311L)
+// C99–C17: provide bool via <stdbool.h>
+#include <stdbool.h>
+#endif
+
 
 
 /*


### PR DESCRIPTION
gcc 15 defaults to the c23 standard which adds `bool` as a keyword. 
https://gcc.gnu.org/gcc-15/porting_to.html
https://en.cppreference.com/w/c/header/stdbool
